### PR TITLE
advertise: add support to advertise beacon frames

### DIFF
--- a/DigiIoT.Maui/Models/DigiBLEManager.cs
+++ b/DigiIoT.Maui/Models/DigiBLEManager.cs
@@ -43,6 +43,11 @@ namespace DigiIoT.Maui.Models
 		/// </summary>
 		public bool IsScanning { get; private set; }
 
+		/// <summary>
+		/// Indicates whether the Bluetooth interface is advertising or not.
+		/// </summary>
+		public bool IsAdvertising { get; private set; }
+
 		// Delegates.
 		/// <summary>
 		/// Notifies that a Bluetooth device has been advertised.
@@ -109,6 +114,7 @@ namespace DigiIoT.Maui.Models
 
 		// Variables.
 		private readonly IAdapter adapter;
+		private BeaconAdvertiseService beaconAdvertiseService;
 
 		// Methods.
 		/// <summary>
@@ -118,7 +124,9 @@ namespace DigiIoT.Maui.Models
 		{
 			// Init variables.
 			adapter = CrossBluetoothLE.Current.Adapter;
+			beaconAdvertiseService = new();
 			IsScanning = false;
+			IsAdvertising = false;
 			// Listen for changes in the bluetooth adapter.
 			CrossBluetoothLE.Current.StateChanged += (o, e) =>
 			{
@@ -367,6 +375,48 @@ namespace DigiIoT.Maui.Models
 					throw new DigiIoTException(ERROR_BLUETOOTH_PERMISSION_NOT_GRANTED);
 				}
 			}
+		}
+
+		/// <summary>
+		/// Starts advertising a custom beacon with the provided parameters.
+		/// </summary>
+		/// <param name="identifier">Identifier or local name of the beacon.</param>
+		/// <param name="companyID">Company ID used in the manufacturer-specific data.</param>
+		/// <param name="manufacturerData">Manufacturer-specific data to advertise.</param>
+		/// <returns><code>true</code> if the process started successfully, <code>false</code>
+		/// otherwise.</returns>
+		public bool StartAdvertisingCustomBeacon(string identifier, byte[] companyID, byte[] manufacturerData)
+		{
+			StopAdvertising();
+			bool started = beaconAdvertiseService.StartAdvertisingCustomBeacon(identifier, companyID, manufacturerData);
+			IsAdvertising = started;
+			return started;
+		}
+
+		/// <summary>
+		/// Starts advertising an iBeacon with the provided parameters.
+		/// </summary>
+		/// <param name="identifier">Identifier or local name of the beacon.</param>
+		/// <param name="uuid">UUID of the iBeacon.</param>
+		/// <param name="major">Major value of the iBeacon.</param>
+		/// <param name="minor">Minor value of the iBeacon.</param>
+		/// <returns><code>true</code> if the process started successfully, <code>false</code>
+		/// otherwise.</returns>
+		public bool StartAdvertisingIBeacon(string identifier, string uuid, ushort major, ushort minor)
+		{
+			StopAdvertising();
+			bool started = beaconAdvertiseService.StartAdvertisingIBeacon(identifier, uuid, major, minor);
+			IsAdvertising = started;
+			return started;
+		}
+
+		/// <summary>
+		/// Stops advertising.
+		/// </summary>
+		public void StopAdvertising()
+		{
+			beaconAdvertiseService.StopAdvertising();
+			IsAdvertising = false;
 		}
 
 		/// <summary>

--- a/DigiIoT.Maui/Platforms/Android/Bluetooth/BLEPermissionsService.cs
+++ b/DigiIoT.Maui/Platforms/Android/Bluetooth/BLEPermissionsService.cs
@@ -49,7 +49,8 @@ namespace DigiIoT.Maui.Services.Bluetooth
 		public override (string androidPermission, bool isRuntime)[] RequiredPermissions => new List<(string androidPermission, bool isRuntime)>
 		{
 			(Manifest.Permission.BluetoothConnect, true),
-			(Manifest.Permission.BluetoothScan, true)
+			(Manifest.Permission.BluetoothScan, true),
+			(Manifest.Permission.BluetoothAdvertise, true)
 		}.ToArray();
 	}
 }

--- a/DigiIoT.Maui/Platforms/Android/Bluetooth/BeaconAdvertiseService.cs
+++ b/DigiIoT.Maui/Platforms/Android/Bluetooth/BeaconAdvertiseService.cs
@@ -1,0 +1,224 @@
+﻿/*
+ * Copyright 2024, Digi International Inc.
+ * 
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+using Android.Bluetooth;
+using Android.Bluetooth.LE;
+using Android.Content;
+using Android.OS;
+
+namespace DigiIoT.Maui.Services.Bluetooth
+{
+	/// <summary>
+	/// Partial class that includes the custom Android implementation of the Beacon
+	/// advertise service.
+	/// </summary>
+	public partial class BeaconAdvertiseService
+	{
+		// Constants.
+		private static readonly byte[] BEACON_ID_IBEACON = [0x02, 0x15];
+
+		private const int START_ADV_TIMEOUT = 1000;  // 1 second
+
+		// Variables.
+		private BluetoothLeAdvertiser _bluetoothLeAdvertiser;
+		private CustomAdvertiseCallback _advertiseCallback;
+		private BluetoothAdapter _bluetoothAdapter;
+
+		private byte[] _advertisementData;
+
+		private ManualResetEventSlim _callbackEvent = new ManualResetEventSlim(false);
+
+		public BeaconAdvertiseService()
+		{
+			var bluetoothManager = (BluetoothManager)Android.App.Application.Context.GetSystemService(Context.BluetoothService);
+			_bluetoothAdapter = bluetoothManager.Adapter;
+		}
+
+		/// <summary>
+		/// Starts advertising a custom beacon with the provided parameters.
+		/// </summary>
+		/// <param name="identifier">Identifier or local name of the beacon.</param>
+		/// <param name="companyID">Company ID used in the manufacturer-specific data.</param>
+		/// <param name="manufacturerData">Manufacturer-specific data to advertise.</param>
+		/// <returns><code>true</code> if the process started successfully, <code>false</code>
+		/// otherwise.</returns>
+		public partial bool StartAdvertisingCustomBeacon(string identifier, byte[] companyID, byte[] manufacturerData)
+		{
+			return StartAdvertisingInternal(identifier, companyID, manufacturerData);
+		}
+
+		/// <summary>
+		/// Starts advertising an iBeacon with the provided parameters.
+		/// </summary>
+		/// <param name="identifier">Identifier or local name of the beacon.</param>
+		/// <param name="uuid">UUID of the iBeacon.</param>
+		/// <param name="major">Major value of the iBeacon.</param>
+		/// <param name="minor">Minor value of the iBeacon.</param>
+		/// <returns><code>true</code> if the process started successfully, <code>false</code>
+		/// otherwise.</returns>
+		public partial bool StartAdvertisingIBeacon(string identifier, string uuid, ushort major, ushort minor)
+		{
+			// Generate the iBeacon payload.
+			var manufacturerData = BEACON_ID_IBEACON.
+				Concat(HexStringToByteArray(uuid)).
+				Concat(BitConverter.GetBytes(major).Reverse()).
+				Concat(BitConverter.GetBytes(minor).Reverse()).
+				Concat(TX_POWER_DEFAULT).ToArray();
+
+			return StartAdvertisingInternal(identifier, COMPANY_ID_APPLE, manufacturerData);
+		}
+
+		/// <summary>
+		/// Starts advertising with the proviced parameters.
+		/// </summary>
+		/// <param name="identifier">Identifier or local name of the beacon.</param>
+		/// <param name="companyID">Company ID used in the manufacturer-specific data.</param>
+		/// <param name="payload">Payload of the beacon.</param>
+		/// <returns><code>true</code> if the process started successfully, <code>false</code>
+		/// otherwise.</returns>
+		private bool StartAdvertisingInternal(string identifier, byte[] companyID, byte[] payload)
+		{
+			if (_bluetoothAdapter == null)
+			{
+				// Handle case where Bluetooth is not supported or not enabled
+				return false;
+			}
+
+			_bluetoothLeAdvertiser = _bluetoothAdapter.BluetoothLeAdvertiser;
+			_advertiseCallback = new CustomAdvertiseCallback(_callbackEvent);
+
+			// Update the advertisement name.
+			_bluetoothAdapter.SetName(identifier);
+
+			// Set the advertisement options.
+			var advertiseSettingsBuilder = new AdvertiseSettings.Builder()
+				.SetAdvertiseMode(AdvertiseMode.LowLatency)
+				.SetTxPowerLevel(AdvertiseTx.PowerHigh);
+			if (Build.VERSION.SdkInt >= BuildVersionCodes.UpsideDownCake)
+				advertiseSettingsBuilder = advertiseSettingsBuilder.SetDiscoverable(true);
+			var advertiseSettings = advertiseSettingsBuilder.Build();
+
+			// Generate the advertisement data.
+			var beaconLenght =
+				(payload != null ? payload.Length + companyID.Length + 2 : 0)  // 2 extra bytes for mfg data length and mfg data tag.
+				+ (identifier != null ? identifier.Length + 2 : 0)             // 2 extra bytes for name length and name tag.
+				+ 3;                                                           // 3 extra bytes for flags length, flags tag and flags value.
+			var advertiseDataBuilder = new AdvertiseData.Builder()
+				.SetIncludeDeviceName(identifier != null && beaconLenght <= 31)  // 31 is the maximum allowed beacon length.
+				.SetIncludeTxPowerLevel(false);
+			if (payload != null)
+				advertiseDataBuilder = advertiseDataBuilder.AddManufacturerData(BitConverter.ToUInt16(companyID, 0), payload);
+			var advertiseData = advertiseDataBuilder.Build();
+
+			// Start advertising.
+			_bluetoothLeAdvertiser.StartAdvertising(advertiseSettings, advertiseData, _advertiseCallback);
+
+			// Wait for the callback to signal completion.
+			_callbackEvent.Wait(START_ADV_TIMEOUT);
+
+			return _advertiseCallback.GetCallbackResult();
+		}
+
+		/// <summary>
+		/// Stops advertising.
+		/// </summary>
+		public partial void StopAdvertising()
+		{
+			_bluetoothLeAdvertiser?.StopAdvertising(_advertiseCallback);
+		}
+
+		/// <summary>
+		/// Converts a hexadecimal string to a byte array.
+		/// </summary>
+		/// <param name="hex">The hexadecimal string to convert.</param>
+		/// <returns>A byte array representing the hexadecimal string.</returns>
+		/// <exception cref="ArgumentNullException">Thrown when the input hex
+		/// string is null.</exception>
+		/// <exception cref="System.FormatException">Thrown when the input hex string
+		/// contains non-hexadecimal characters.</exception>
+		public static byte[] HexStringToByteArray(string hex)
+		{
+			if (hex == null)
+				throw new ArgumentNullException(nameof(hex), "Hex string cannot be null.");
+
+			hex = hex.Replace("-", "");
+			if (hex.Length % 2 != 0)
+				hex = "0" + hex;
+
+			byte[] bytes = new byte[hex.Length / 2];
+			for (int i = 0; i < hex.Length; i += 2)
+				bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
+			return bytes;
+		}
+	}
+
+	/// <summary>
+	/// Callback required for the advertising process. Notifies about the
+	/// status of the start advertising process.
+	/// </summary>
+	public class CustomAdvertiseCallback : AdvertiseCallback
+	{
+		// Variables.
+		private bool _callbackResult = false;
+
+		private ManualResetEventSlim _callbackEvent;
+
+		/// <summary>
+		/// Class constructor. Instantiates a new <code>CustomAdvertiseCallback</code>
+		/// with the provided parameters.
+		/// </summary>
+		/// <param name="callbackEvent">The callback event to notify when a result is received.</param>
+		public CustomAdvertiseCallback(ManualResetEventSlim callbackEvent)
+		{
+			_callbackEvent = callbackEvent;
+			_callbackEvent.Reset();
+		}
+
+		/// <summary>
+		/// <inheritdoc/>
+		/// </summary>
+		public override void OnStartFailure(AdvertiseFailure errorCode)
+		{
+			base.OnStartFailure(errorCode);
+
+			// Set the callback result.
+			_callbackResult = false;
+			_callbackEvent.Set();
+		}
+
+		/// <summary>
+		/// <inheritdoc/>
+		/// </summary>
+		public override void OnStartSuccess(AdvertiseSettings settingsInEffect)
+		{
+			base.OnStartSuccess(settingsInEffect);
+
+			// Set the callback result.
+			_callbackResult = true;
+			_callbackEvent.Set();
+		}
+
+		/// <summary>
+		/// Returns the callback result.
+		/// </summary>
+		/// <returns><code>true</code> if the result was success, <code>false</code>
+		/// otherwise.</returns>
+		public bool GetCallbackResult()
+		{
+			return _callbackResult;
+		}
+	}
+}

--- a/DigiIoT.Maui/Platforms/Windows/Bluetooth/BeaconAdvertiseService.cs
+++ b/DigiIoT.Maui/Platforms/Windows/Bluetooth/BeaconAdvertiseService.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * Copyright 2024, Digi International Inc.
+ * 
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+namespace DigiIoT.Maui.Services.Bluetooth
+{
+	/// <summary>
+	/// Partial class that includes the custom Windows implementation of the Beacon
+	/// advertise service.
+	/// </summary>
+	public partial class BeaconAdvertiseService
+	{
+		/// <summary>
+		/// Starts advertising a custom beacon with the provided parameters.
+		/// </summary>
+		/// <param name="identifier">Identifier or local name of the beacon.</param>
+		/// <param name="companyID">Company ID used in the manufacturer-specific data.</param>
+		/// <param name="manufacturerData">Manufacturer-specific data to advertise.</param>
+		/// <returns><code>true</code> if the process started successfully, <code>false</code>
+		/// otherwise.</returns>
+		public partial bool StartAdvertisingCustomBeacon(string identifier, byte[] companyID, byte[] manufacturerData)
+		{
+			throw new NotSupportedException("Service not implemented.");
+		}
+
+		/// <summary>
+		/// Starts advertising an iBeacon with the provided parameters.
+		/// </summary>
+		/// <param name="identifier">Identifier or local name of the beacon.</param>
+		/// <param name="uuid">UUID of the iBeacon.</param>
+		/// <param name="major">Major value of the iBeacon.</param>
+		/// <param name="minor">Minor value of the iBeacon.</param>
+		/// <returns><code>true</code> if the process started successfully, <code>false</code>
+		/// otherwise.</returns>
+		public partial bool StartAdvertisingIBeacon(string identifier, string uuid, ushort major, ushort minor)
+		{
+			throw new NotSupportedException("Service not implemented.");
+		}
+
+		/// <summary>
+		/// Stops advertising.
+		/// </summary>
+		public partial void StopAdvertising()
+		{
+			throw new NotSupportedException("Service not implemented.");
+		}
+	}
+}

--- a/DigiIoT.Maui/Platforms/iOS/Bluetooth/BeaconAdvertiseService.cs
+++ b/DigiIoT.Maui/Platforms/iOS/Bluetooth/BeaconAdvertiseService.cs
@@ -1,0 +1,164 @@
+﻿/*
+ * Copyright 2024, Digi International Inc.
+ * 
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+using CoreBluetooth;
+using CoreLocation;
+using Foundation;
+using UIKit;
+
+namespace DigiIoT.Maui.Services.Bluetooth
+{
+	/// <summary>
+	/// Partial class that includes the custom iOS implementation of the Beacon
+	/// advertise service.
+	/// </summary>
+	public partial class BeaconAdvertiseService
+	{
+		// Constants.
+		private const string ADVERT_BEACON_KEY = "kCBAdvDataAppleBeaconKey";
+
+		// Variables.
+		private CBPeripheralManager _peripheralManager;
+		private NSDictionary _advertisementData;
+
+		/// <summary>
+		/// Starts advertising a custom beacon with the provided parameters.
+		/// </summary>
+		/// <param name="identifier">Identifier or local name of the beacon.</param>
+		/// <param name="companyID">Company ID used in the manufacturer-specific data.</param>
+		/// <param name="manufacturerData">Manufacturer-specific data to advertise.</param>
+		/// <returns><code>true</code> if the process started successfully, <code>false</code>
+		/// otherwise.</returns>
+		public partial bool StartAdvertisingCustomBeacon(string identifier, byte[] companyID, byte[] manufacturerData)
+		{
+			// The way a custom beacon would be generated in iOS is as follows:
+			//
+			//// Convert the byte array to NSData
+			//var nsData = NSData.FromArray([.. companyID, .. manufacturerData]);
+			//
+			//// Set up the advertisement data
+			//_advertisementData = new NSDictionary(
+			//	CBAdvertisement.DataLocalNameKey, identifier,
+			//	CBAdvertisement.DataManufacturerDataKey, nsData
+			//);
+			//
+			// However, the 'DataManufacturerDataKey' tag is not allowed for advertisement, so
+			// custom beacons are not available in iOS.
+
+			throw new NotSupportedException("Manufacturer data AD is not supported in iOS.");
+		}
+
+		/// <summary>
+		/// Starts advertising an iBeacon with the provided parameters.
+		/// </summary>
+		/// <param name="identifier">Identifier or local name of the beacon.</param>
+		/// <param name="uuid">UUID of the iBeacon.</param>
+		/// <param name="major">Major value of the iBeacon.</param>
+		/// <param name="minor">Minor value of the iBeacon.</param>
+		/// <returns><code>true</code> if the process started successfully, <code>false</code>
+		/// otherwise.</returns>
+		public partial bool StartAdvertisingIBeacon(string identifier, string uuid, ushort major, ushort minor)
+		{
+			// Initialize vars.
+			var proximityUUID = new NSUuid(uuid);
+
+			if (UIDevice.CurrentDevice.CheckSystemVersion(17, 0))
+			{
+				// For iOS 17.0 and later
+				// 'CLBeaconIdentityConstraint' and 'CLBeaconRegion' are deprecated for iOS 17
+				// and later. As there is not a clear API to generate the iBeacon payload now,
+				// generate it manually.
+				var beaconUUIDBytes = proximityUUID.GetBytes();
+				var majorBytes = BitConverter.GetBytes(major);
+				var minorBytes = BitConverter.GetBytes(minor);
+
+				if (BitConverter.IsLittleEndian)
+				{
+					Array.Reverse(majorBytes);
+					Array.Reverse(minorBytes);
+				}
+
+				var beaconData = new byte[21];
+				Array.Copy(beaconUUIDBytes, 0, beaconData, 0, 16);
+				Array.Copy(majorBytes, 0, beaconData, 16, 2);
+				Array.Copy(minorBytes, 0, beaconData, 18, 2);
+				Array.Copy(TX_POWER_DEFAULT, 0, beaconData, 20, 1);
+
+				var beaconNSData = NSData.FromArray(beaconData);
+
+				_advertisementData = new NSDictionary(
+					CBAdvertisement.DataLocalNameKey, identifier,
+					new NSString(ADVERT_BEACON_KEY), beaconNSData
+				);
+			}
+			else if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+			{
+				// For iOS 13.0 to 16.x
+				var beaconIdentityConstraint = new CLBeaconIdentityConstraint(proximityUUID, major, minor);
+				var beaconRegion = new CLBeaconRegion(beaconIdentityConstraint, identifier);
+				_advertisementData = beaconRegion.GetPeripheralData(null);
+			}
+			else
+			{
+				// For iOS 12.x and earlier
+				var beaconRegion = new CLBeaconRegion(proximityUUID, major, minor, identifier);
+				_advertisementData = beaconRegion.GetPeripheralData(null);
+			}
+
+			// Start advertising data.
+			return StartAdvertisingInternal();
+		}
+
+		/// <summary>
+		/// Starts advertising data.
+		/// </summary>
+		/// <returns><code>true</code> if the process started successfully, <code>false</code>
+		/// otherwise.</returns>
+		private bool StartAdvertisingInternal()
+		{
+			// Initialize peripheral manager if not already done.
+			if (_peripheralManager == null)
+			{
+				_peripheralManager = new CBPeripheralManager();
+				_peripheralManager.StateUpdated += (sender, e) =>
+				{
+					if (_peripheralManager.State == CBManagerState.PoweredOn && _advertisementData != null)
+					{
+						_peripheralManager.StartAdvertising(_advertisementData);
+					}
+				};
+			}
+
+			if (_peripheralManager.State == CBManagerState.PoweredOn && _advertisementData != null)
+			{
+				_peripheralManager.StartAdvertising(_advertisementData);
+			}
+
+			return true;
+		}
+
+		/// <summary>
+		/// Stops advertising.
+		/// </summary>
+		public partial void StopAdvertising()
+		{
+			_peripheralManager?.StopAdvertising();
+			// Reset data so that it does not start advertising automatically if the
+			// interface goes ON.
+			_advertisementData = null;
+		}
+	}
+}

--- a/DigiIoT.Maui/Services/Bluetooth/BeaconAdvertiseService.cs
+++ b/DigiIoT.Maui/Services/Bluetooth/BeaconAdvertiseService.cs
@@ -1,0 +1,73 @@
+﻿/*
+ * Copyright 2024, Digi International Inc.
+ * 
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+namespace DigiIoT.Maui.Services.Bluetooth
+{
+	/// <summary>
+	/// Partial class that defines the shared implementation of the Beacon
+	/// advertise service.
+	/// </summary>
+	public partial class BeaconAdvertiseService
+	{
+		// Constants.
+		/// <summary>
+		/// Beaconing company ID corresponding to Apple.
+		/// </summary>
+		public static readonly byte[] COMPANY_ID_APPLE = [0x4C, 0x00];
+		/// <summary>
+		/// Beaconing company ID corresponding to Digi International inc.
+		/// </summary>
+		public static readonly byte[] COMPANY_ID_DIGI = [0xDB, 0x02];
+
+		private readonly byte[] TX_POWER_DEFAULT = [0xC8];
+
+		/// <summary>
+		/// Starts advertising a custom beacon with the provided parameters.
+		/// </summary>
+		/// <param name="identifier">Identifier or local name of the beacon.</param>
+		/// <param name="companyID">Company ID used in the manufacturer-specific data.</param>
+		/// <param name="manufacturerData">Manufacturer-specific data to advertise.</param>
+		/// <returns><code>true</code> if the process started successfully, <code>false</code>
+		/// otherwise.</returns>
+		public partial bool StartAdvertisingCustomBeacon(string identifier, byte[] companyID, byte[] manufacturerData);
+
+		/// <summary>
+		/// Starts advertising an iBeacon with the provided parameters.
+		/// </summary>
+		/// <param name="identifier">Identifier or local name of the beacon.</param>
+		/// <param name="uuid">UUID of the iBeacon.</param>
+		/// <param name="major">Major value of the iBeacon.</param>
+		/// <param name="minor">Minor value of the iBeacon.</param>
+		/// <returns><code>true</code> if the process started successfully, <code>false</code>
+		/// otherwise.</returns>
+		public partial bool StartAdvertisingIBeacon(string identifier, string uuid, ushort major, ushort minor);
+
+		/// <summary>
+		/// Stops advertising.
+		/// </summary>
+		public partial void StopAdvertising();
+
+		/// <summary>
+		/// Generates a random UUID.
+		/// </summary>
+		/// <returns>A string representation of the random UUID.</returns>
+		public static string GenerateNewUUID()
+		{
+			Guid uuid = Guid.NewGuid();
+			return uuid.ToString().ToUpper();
+		}
+	}
+}


### PR DESCRIPTION
- Added a new service with custom implementetions in iOS and Android to advertise Bluetooth data, either custom beacons or iBeacons.
- Although the new service can be instantiated to work with it in an independent way, the suggested workflow is to access this new feature through the 'DigiBLEManager'.
- Added 'Bluetooth Advertise' permission to the list of persmissions requested by the Android implementetion of the Bluetooh permissions service.