### PR TITLE
provision: first implementation of the Digi Remote Manager provisioni…

### DIFF
--- a/DigiIoT.Maui/DigiIoT.Maui.csproj
+++ b/DigiIoT.Maui/DigiIoT.Maui.csproj
@@ -39,6 +39,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	  <PackageReference Include="XBeeLibrary.Core" Version="1.0.4" />
 	  <PackageReference Include="Plugin.BLE" Version="3.1.0" />
 	  <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.3" />

--- a/DigiIoT.Maui/Exceptions/DRMException.cs
+++ b/DigiIoT.Maui/Exceptions/DRMException.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * Copyright 2024, Digi International Inc.
+ * 
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+namespace DigiIoT.Maui.Exceptions
+{
+	/// <summary>
+	/// Generic Digi Remote Manager exception. This class indicates conditions that an application might want
+	/// to catch. This exception can be thrown when any problem related to a Digi Remote Manager operation occurs.
+	/// </summary>
+	public class DRMException : Exception
+	{
+		/// <summary>
+		/// HTTP status code associated with the error, if available.
+		/// </summary>
+		public int? StatusCode { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DRMException"/> class with a specified error
+		/// message and optional HTTP status code.
+		/// </summary>
+		/// <param name="message">The error message describing the exception.</param>
+		/// <param name="statusCode">The HTTP status code associated with the error (optional).</param>
+		/// <param name="innerException">The inner exception, if any, that caused this exception (optional).</param>
+		public DRMException(string message, int? statusCode = null, Exception innerException = null)
+			: base(message, innerException)
+		{
+			StatusCode = statusCode;
+		}
+	}
+}

--- a/DigiIoT.Maui/Models/DRM/DRMAccount.cs
+++ b/DigiIoT.Maui/Models/DRM/DRMAccount.cs
@@ -1,0 +1,77 @@
+﻿/*
+ * Copyright 2024, Digi International Inc.
+ * 
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+using DigiIoT.Maui.Utils;
+using DigiIoT.Maui.Exceptions;
+
+namespace DigiIoT.Maui.Models.DRM
+{
+    /// <summary>
+    /// Class representing a Digi Remote Manager account for cloud operations.
+    /// </summary>
+    public class DRMAccount
+	{
+		// Properties.
+		/// <summary>
+		/// Username of the Digi Remote Manager account.
+		/// </summary>
+		public string Username { get; }
+
+		/// <summary>
+		/// Password of the Digi Remote Manager account.
+		/// </summary>
+		public string Password { get; }
+
+		/// <summary>
+		/// Class constructor. Instantiates a new <see cref="DRMAccount"/> object with the given 
+		/// parameters.
+		/// </summary>
+		/// <param name="username">Digi Remote Manager account username.</param>
+		/// <param name="password">Digi Remote Manager account password.</param>
+		/// <exception cref="ArgumentNullException">If username or password are null.</exception>
+		public DRMAccount(string username, string password)
+		{
+			Username = username ?? throw new ArgumentNullException(nameof(username));
+			Password = password ?? throw new ArgumentNullException(nameof(password));
+		}
+
+		/// <summary>
+		/// Provisions a device to Digi Remote Manager using an optional install code.
+		/// </summary>
+		/// <param name="deviceID">The ID of the device to provision.</param>
+		/// <param name="installCode">The optional install code for the device.</param>
+		/// <returns>A task that returns the result of the provisioning operation.</returns>
+		/// <exception cref="ArgumentNullException">If device ID is null.</exception>
+		/// <exception cref="ArgumentException">If the device ID is invalid.</exception>
+		/// <exception cref="DRMException">If the provisioning process fails.</exception>
+		public async Task<DeviceProvisionResult> ProvisionDevice(string deviceID, string installCode = null)
+		{
+			return await DRMUtils.ProvisionDevice(this, deviceID, installCode);
+		}
+
+		/// <summary>
+		/// Provisions a list of devices to Digi Remote Manager using an optional install code.
+		/// </summary>
+		/// <param name="devices">The list of devices to provision, each containing an ID and an optional install code.</param>
+		/// <exception cref="ArgumentNullException">If the device list is null.</exception>
+		/// <exception cref="ArgumentException">If the device list is empty.</exception>
+		/// <exception cref="DRMException">If the request fails for all devices or the server response is invalid.</exception>
+		public async Task<List<DeviceProvisionResult>> ProvisionDevices(List<DeviceProvisionRequest> devices)
+		{
+			return await DRMUtils.ProvisionDevices(this, devices);
+		}
+	}
+}

--- a/DigiIoT.Maui/Models/DRM/DeviceProvisionRequest.cs
+++ b/DigiIoT.Maui/Models/DRM/DeviceProvisionRequest.cs
@@ -1,0 +1,39 @@
+﻿/*
+ * Copyright 2024, Digi International Inc.
+ * 
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+using Newtonsoft.Json;
+
+namespace DigiIoT.Maui.Models.DRM
+{
+    /// <summary>
+    /// Represents a Digi device to be provisioned to Digi Remote Manager.
+    /// </summary>
+    public class DeviceProvisionRequest
+    {
+        // Properties.
+        /// <summary>
+        /// The ID of the device to provision.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The install code for the device (optional).
+        /// </summary>
+        [JsonProperty("install_code")]
+        public string InstallCode { get; set; }
+    }
+}

--- a/DigiIoT.Maui/Models/DRM/DeviceProvisionResult.cs
+++ b/DigiIoT.Maui/Models/DRM/DeviceProvisionResult.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * Copyright 2024, Digi International Inc.
+ * 
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+namespace DigiIoT.Maui.Models.DRM
+{
+    /// <summary>
+    /// Represents the result of provisioning a Digi device.
+    /// </summary>
+    public class DeviceProvisionResult
+    {
+        // Properties.
+        /// <summary>
+        /// The ID of the device.
+        /// </summary>
+        public string DeviceId { get; set; }
+
+        /// <summary>
+        /// Whether the device provisioning was successful or not.
+        /// </summary>
+        public bool IsSuccess { get; set; }
+
+        /// <summary>
+        /// The error message if provisioning failed (optional).
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
+        /// The error code if provisioning failed (optional).
+        /// </summary>
+        public int? ErrorCode { get; set; }
+    }
+}

--- a/DigiIoT.Maui/Types/DeviceProvisionTypes.cs
+++ b/DigiIoT.Maui/Types/DeviceProvisionTypes.cs
@@ -1,0 +1,113 @@
+﻿/*
+ * Copyright 2024, Digi International Inc.
+ * 
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+using Newtonsoft.Json;
+
+namespace DigiIoT.Maui.Types
+{
+
+    /// <summary>
+    /// Represents the response from Digi Remote Manager when provisioning multiple devices.
+    /// </summary>
+    internal class DeviceProvisionResponse
+    {
+        /// <summary>
+        /// Gets or sets the total number of devices included in the response.
+        /// </summary>
+        [JsonProperty("count")]
+        public int Count { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of results for each device in the provisioning operation.
+        /// </summary>
+        [JsonProperty("list")]
+        public List<DeviceResult> List { get; set; }
+    }
+
+    /// <summary>
+    /// Represents the raw result of a single device provisioning from the API.
+    /// </summary>
+    internal class DeviceResult
+    {
+        // Properties.
+        /// <summary>
+        /// The error status code if the provisioning failed (optional).
+        /// </summary>
+        [JsonProperty("error_status")]
+        public int? ErrorStatus { get; set; }
+
+        /// <summary>
+        /// The error message if the provisioning failed (optional).
+        /// </summary>
+        [JsonProperty("error_message")]
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
+        /// The context of the error, containing additional details (optional).
+        /// </summary>
+        [JsonProperty("error_context")]
+        public ErrorContext ErrorContext { get; set; }
+
+        /// <summary>
+        /// The ID of the device being provisioned.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+
+    /// <summary>
+    /// Represents additional context information for a device provisioning error.
+    /// </summary>
+    internal class ErrorContext
+    {
+        // Properties.
+        /// <summary>
+        /// The ID of the device involved in the error.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The install code of the device involved in the error (optional).
+        /// </summary>
+        [JsonProperty("install_code")]
+        public string InstallCode { get; set; }
+
+        /// <summary>
+        /// The customer ID associated with the device.
+        /// </summary>
+        [JsonProperty("customer_id")]
+        public int CustomerId { get; set; }
+
+        /// <summary>
+        /// Whether the device is in a maintenance window or not.
+        /// </summary>
+        [JsonProperty("in_maintenance_window")]
+        public string InMaintenanceWindow { get; set; }
+
+        /// <summary>
+        /// Whether the device has an authenticated connection or not.
+        /// </summary>
+        [JsonProperty("authenticated_connection")]
+        public bool AuthenticatedConnection { get; set; }
+
+        /// <summary>
+        /// The group associated with the device (optional).
+        /// </summary>
+        [JsonProperty("group")]
+        public string Group { get; set; }
+    }
+}

--- a/DigiIoT.Maui/Utils/DRMUtils.cs
+++ b/DigiIoT.Maui/Utils/DRMUtils.cs
@@ -1,0 +1,226 @@
+﻿/*
+ * Copyright 2024, Digi International Inc.
+ * 
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+using DigiIoT.Maui.Exceptions;
+using DigiIoT.Maui.Models.DRM;
+using DigiIoT.Maui.Types;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace DigiIoT.Maui.Utils
+{
+    /// <summary>
+    /// Class containing Digi Remote Manager related operations.
+    /// </summary>
+    public class DRMUtils
+	{
+		// Constants.
+		private const string URL_REMOTE_MANAGER = "https://devicecloud.digi.com";
+		private const string ENDPOINT_DEVICES_INV = $"{URL_REMOTE_MANAGER}/ws/v1/devices/inventory";
+
+		private static readonly Regex DEVICE_ID_REGEX = new Regex(
+			@"^[0-9a-fA-F]{8}-[0-9a-fA-F]{8}-[0-9a-fA-F]{8}-[0-9a-fA-F]{8}$",
+			RegexOptions.Compiled);
+
+
+		private const string ERROR_DEVICE_ID_EMPTY = "Device ID cannot be null or empty.";
+		private const string ERROR_DEVICE_ID_INVALID = "Device ID format is not valid. Expected format is 00000000-00000000-00000000-00000000.";
+		private const string ERROR_DEVICE_LIST_EMPTY = "Device list cannot be null or empty.";
+		private const string ERROR_PROVISIONING_FAILED = "Device provisioning failed. Status Code: {0}, Details: {1}";
+		private const string ERROR_NETWORK = "A network error occurred while provisioning the device.";
+		private const string ERROR_OTHER = "An unexpected error occurred.";
+
+		/// <summary>
+		/// Provisions a single device to Digi Remote Manager using a <see cref="DRMAccount"/> and an optional install code.
+		/// </summary>
+		/// <param name="drmAccount">The <see cref="DRMAccount"/> containing authentication credentials.</param>
+		/// <param name="deviceId">The ID of the device to provision.</param>
+		/// <param name="installCode">The optional install code for the device.</param>
+		/// <returns>A task that returns the result of the provisioning operation.</returns>
+		/// <exception cref="ArgumentNullException">If the DRM account or device ID is null.</exception>
+		/// <exception cref="ArgumentException">If the device ID is invalid.</exception>
+		/// <exception cref="DRMException">If the provisioning process fails.</exception>
+		public static async Task<DeviceProvisionResult> ProvisionDevice(DRMAccount drmAccount, string deviceId, string installCode = null)
+		{
+			if (drmAccount == null)
+				throw new ArgumentNullException(nameof(drmAccount));
+
+			return await ProvisionDevice(drmAccount.Username, drmAccount.Password, deviceId, installCode);
+		}
+
+		/// <summary>
+		/// Provisions a single device to Digi Remote Manager using raw credentials and an optional install code.
+		/// </summary>
+		/// <param name="username">The username for Digi Remote Manager authentication.</param>
+		/// <param name="password">The password for Digi Remote Manager authentication.</param>
+		/// <param name="deviceId">The ID of the device to provision.</param>
+		/// <param name="installCode">The optional install code for the device.</param>
+		/// <returns>A task that returns the result of the provisioning operation.</returns>
+		/// <exception cref="ArgumentNullException">If the username, password, or device ID is null.</exception>
+		/// <exception cref="ArgumentException">If the device ID is invalid.</exception>
+		/// <exception cref="DRMException">If the provisioning process fails.</exception>
+		public static async Task<DeviceProvisionResult> ProvisionDevice(string username, string password, string deviceId, string installCode = null)
+		{
+			ValidateDeviceId(deviceId);
+
+			var deviceRequest = new DeviceProvisionRequest { Id = deviceId, InstallCode = installCode ?? string.Empty };
+			var results = await ProvisionDevices(username, password, new List<DeviceProvisionRequest> { deviceRequest });
+
+			// Since we are provisioning one device, return the first result.
+			return results[0];
+		}
+
+		/// <summary>
+		/// Provisions multiple devices to Digi Remote Manager using a <see cref="DRMAccount"/>.
+		/// </summary>
+		/// <param name="drmAccount">The <see cref="DRMAccount"/> containing authentication credentials.</param>
+		/// <param name="devices">The list of devices to provision, each containing an ID and an optional install code.</param>
+		/// <returns>A task that returns a list of provisioning results for each device.</returns>
+		/// <exception cref="ArgumentNullException">If the DRM account or device list is null.</exception>
+		/// <exception cref="ArgumentException">If the device list is empty.</exception>
+		/// <exception cref="DRMException">If the request fails for all devices or the server response is invalid.</exception>
+		public static async Task<List<DeviceProvisionResult>> ProvisionDevices(DRMAccount drmAccount, List<DeviceProvisionRequest> devices)
+		{
+			if (drmAccount == null)
+				throw new ArgumentNullException(nameof(drmAccount));
+
+			return await ProvisionDevices(drmAccount.Username, drmAccount.Password, devices);
+		}
+
+		/// <summary>
+		/// Provisions multiple devices to Digi Remote Manager using raw credentials.
+		/// </summary>
+		/// <param name="drmUser">The username for Digi Remote Manager authentication.</param>
+		/// <param name="drmPassword">The password for Digi Remote Manager authentication.</param>
+		/// <param name="devices">The list of devices to provision, each containing an ID and an optional install code.</param>
+		/// <returns>A task that returns a list of provisioning results for each device.</returns>
+		/// <exception cref="ArgumentNullException">If the DRM account or device list is null.</exception>
+		/// <exception cref="ArgumentException">If the device list is empty.</exception>
+		/// <exception cref="DRMException">If the request fails for all devices or the server response is invalid.</exception>
+		public static async Task<List<DeviceProvisionResult>> ProvisionDevices(string drmUser, string drmPassword, List<DeviceProvisionRequest> devices)
+		{
+			if (string.IsNullOrWhiteSpace(drmUser))
+				throw new ArgumentNullException(nameof(drmUser));
+
+			if (string.IsNullOrWhiteSpace(drmPassword))
+				throw new ArgumentNullException(nameof(drmPassword));
+
+			if (devices == null || devices.Count == 0)
+				throw new ArgumentException(ERROR_DEVICE_LIST_EMPTY, nameof(devices));
+
+			using (HttpClient client = new HttpClient())
+			{
+				try
+				{
+					string auth = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{drmUser}:{drmPassword}"));
+					client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", auth);
+
+					string jsonPayload = JsonConvert.SerializeObject(devices, Formatting.None, new JsonSerializerSettings
+					{
+						NullValueHandling = NullValueHandling.Ignore
+					});
+
+					HttpContent content = new StringContent(jsonPayload, Encoding.UTF8, "application/json");
+					HttpResponseMessage response = await client.PostAsync(ENDPOINT_DEVICES_INV, content);
+
+					string responseBody = await response.Content.ReadAsStringAsync();
+
+					if (response.StatusCode == HttpStatusCode.Created) // 201
+					{
+						// All devices were provisioned successfully. Create results for each one.
+						var results = new List<DeviceProvisionResult>();
+
+						foreach (var device in devices)
+						{
+							results.Add(new DeviceProvisionResult
+							{
+								DeviceId = device.Id,
+								IsSuccess = true,
+								ErrorMessage = null,
+								ErrorCode = null
+							});
+						}
+						return results;
+					}
+					else if (response.StatusCode == HttpStatusCode.MultiStatus) // 207
+					{
+						// Handle partial success or failure for multiple devices.
+						var responseObject = JsonConvert.DeserializeObject<DeviceProvisionResponse>(responseBody);
+						var results = new List<DeviceProvisionResult>();
+
+						foreach (var deviceResult in responseObject.List)
+						{
+							results.Add(new DeviceProvisionResult
+							{
+								DeviceId = deviceResult.ErrorContext?.Id ?? deviceResult.Id,
+								IsSuccess = deviceResult.ErrorStatus == null,
+								ErrorMessage = deviceResult.ErrorMessage,
+								ErrorCode = deviceResult.ErrorStatus
+							});
+						}
+						return results;
+					}
+					else
+					{
+						// Handle other unexpected statuses.
+						string errorMessage = await response.Content.ReadAsStringAsync();
+						try
+						{
+							// Attempt to parse the content as JSON and extract "error_message".
+							var errorObject = JsonConvert.DeserializeObject<Dictionary<string, object>>(errorMessage);
+							if (errorObject != null && errorObject.ContainsKey("error_message"))
+								errorMessage = errorObject["error_message"]?.ToString();
+						}
+						catch (JsonException ignore) { }
+
+						throw new DRMException(
+							string.Format(ERROR_PROVISIONING_FAILED, response.StatusCode, errorMessage),
+							(int)response.StatusCode);
+					}
+				}
+				catch (HttpRequestException ex)
+				{
+					throw new DRMException(ERROR_NETWORK, null, ex);
+				}
+				catch (DRMException)
+				{
+					throw;
+				}
+				catch (Exception ex)
+				{
+					throw new DRMException(ERROR_OTHER, null, ex);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Validates the provided device ID.
+		/// </summary>
+		/// <param name="deviceID">Device ID to validate.</param>
+		/// <exception cref="ArgumentException">If the provided device ID is not valid.</exception>
+		private static void ValidateDeviceId(string deviceID)
+		{
+			if (string.IsNullOrEmpty(deviceID))
+				throw new ArgumentException(ERROR_DEVICE_ID_EMPTY, nameof(deviceID));
+
+			if (!DEVICE_ID_REGEX.IsMatch(deviceID))
+				throw new ArgumentException(ERROR_DEVICE_ID_INVALID, nameof(deviceID));
+		}
+	}
+}


### PR DESCRIPTION
…ng API

- Added a new API to allow customers to provision (register) devices in a Digi Remote Manager account individually or by batch. API is located in the 'DigiIoT.Maui.Utils.DRMUtils' class.
- Added the new class 'DRMAccount' that can be used by the new provisioning API or to provision a device or list of devices directly from the 'DRMAccount'.
- Exceptions generated by the new API are thrown as 'DRMException'. It can include an HTTP status code from the HTTP operation that failed.
- Added other model classes used to manage the requests and responses with DRM.