### PR TITLE
provision: use SocketsHttpHandler to prevent credential reuse on iOS

### DIFF
--- a/DigiIoT.Maui/Utils/DRMUtils.cs
+++ b/DigiIoT.Maui/Utils/DRMUtils.cs
@@ -124,7 +124,7 @@ namespace DigiIoT.Maui.Utils
 			if (devices == null || devices.Count == 0)
 				throw new ArgumentException(ERROR_DEVICE_LIST_EMPTY, nameof(devices));
 
-			using (HttpClient client = new HttpClient())
+			using (HttpClient client = new HttpClient(new SocketsHttpHandler()))
 			{
 				try
 				{


### PR DESCRIPTION
- On iOS, HttpClient defaults to NSUrlSessionHandler, which maintains open HTTP connections and may reuse authentication headers across requests.
- This caused ProvisionDevices() to use the original credentials even when different ones were provided in subsequent calls.
- Switching to SocketsHttpHandler ensures that each request uses the correct credentials.